### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ If you're having issues getting the above steps to work, see the [Troubleshootin
 To learn more about React Native, take a look at the following resources:
 
 - [React Native Website](https://reactnative.dev) - learn more about React Native.
-- [Getting Started](https://reactnative.dev/docs/environment-setup) - an **overview** of React Native and how setup your environment.
+- [Getting Started](https://reactnative.dev/docs/environment-setup) - an **overview** of React Native and how to set up your environment.
 - [Learn the Basics](https://reactnative.dev/docs/getting-started) - a **guided tour** of the React Native **basics**.
 - [Blog](https://reactnative.dev/blog) - read the latest official React Native **Blog** posts.
 - [`@facebook/react-native`](https://github.com/facebook/react-native) - the Open Source; GitHub **repository** for React Native.


### PR DESCRIPTION
## Summary
- fix a small typo in README

## Testing
- `npm test` *(fails: Cannot find module '@shopify/react-native-skia')*
- `npm run lint` *(fails: 2 errors, 2 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6874bdd60b34832aab164c900ea00ebf