### PR TITLE
Improve SnakeGame UI

### DIFF
--- a/SnakeGame.tsx
+++ b/SnakeGame.tsx
@@ -181,7 +181,7 @@ export default function SnakeGame({ initialSpeed, onExit }: SnakeGameProps) {
 
   return (
     <View style={styles.container}>
-      <Canvas style={{ width, height, position: 'absolute', top: 0, left: 0 }}>
+      <Canvas pointerEvents="none" style={{ width, height, position: 'absolute', top: 0, left: 0 }}>
         {snake.map((p, i) => (
           <Circle
             key={i}
@@ -217,6 +217,10 @@ export default function SnakeGame({ initialSpeed, onExit }: SnakeGameProps) {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+    width: '100%',
+    height: '100%',
+    borderWidth: 2,
+    borderColor: '#00BFFF',
   },
   score: {
     position: 'absolute',


### PR DESCRIPTION
## Summary
- ensure touch events reach the joystick by disabling Canvas pointer events
- add a blue border and enforce full-screen layout for the game view

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687888a4adf0832abad4254d835b3e94