### PR TITLE
Fix Android workflow build step

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -35,8 +35,6 @@ jobs:
 
         run: chmod +x android/gradlew
 
-      - name: Prepare React Native Gradle Plugin
-        run: npx react-native-gradle-plugin
 
       - name: Build Release APK
 


### PR DESCRIPTION
## Summary
- remove unused `react-native-gradle-plugin` invocation from workflow

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687b458f5564832aa8438b0c8c16b977